### PR TITLE
Line option to `plot_errors()`

### DIFF
--- a/R/plot_errors.R
+++ b/R/plot_errors.R
@@ -35,9 +35,9 @@ plot_errors.errprof <- function(dataIn, plotType = c('boxplot'), ...){
     toplo <- melt(toplo)
     percs <- dataIn$MissingPercent
     toplo$L2 <- factor(toplo$L2, levels = unique(toplo$L2), labels = percs)
-    names(toplo) <- c('Error value', 'Percent of missing values', 'Methods')
+    names(toplo) <- c('Error value', 'Percent of missing observations', 'Methods')
 
-    p <- ggplot(toplo, aes(x = `Percent of missing values`, y = `Error value`)) +
+    p <- ggplot(toplo, aes(x = `Percent of missing observations`, y = `Error value`)) +
       ggtitle(dataIn$Parameter) +
       geom_boxplot(aes(fill = Methods)) +
       theme_bw()
@@ -50,12 +50,12 @@ plot_errors.errprof <- function(dataIn, plotType = c('boxplot'), ...){
   toplo <- data.frame(dataIn[-1])
   toplo <- melt(toplo, id.var = 'MissingPercent')
   toplo$MissingPercent <- factor(toplo$MissingPercent)
-  names(toplo) <- c('Percent of missing values', 'Methods', 'Error value')
+  names(toplo) <- c('Percent of missing observations', 'Methods', 'Error value')
 
   # barplot
   if(plotType == 'bar'){
 
-    p <- ggplot(toplo, aes(x = `Percent of missing values`, y = `Error value`)) +
+    p <- ggplot(toplo, aes(x = `Percent of missing observations`, y = `Error value`)) +
       ggtitle(dataIn$Parameter) +
       geom_bar(aes(fill = Methods), stat = 'identity', position = 'dodge') +
       theme_bw()
@@ -67,7 +67,7 @@ plot_errors.errprof <- function(dataIn, plotType = c('boxplot'), ...){
   # line plot
   if(plotType == 'line'){
 
-    p <- ggplot(toplo, aes(x = `Percent of missing values`, y = `Error value`, group = Methods)) +
+    p <- ggplot(toplo, aes(x = `Percent of missing observations`, y = `Error value`, group = Methods)) +
       ggtitle(dataIn$Parameter) +
       geom_line() +
       geom_point(aes(fill = Methods), shape = 21, size = 5) +

--- a/R/plot_errors.R
+++ b/R/plot_errors.R
@@ -1,10 +1,10 @@
 #' Function to plot the Error Comparison
 #'
 #' @param dataIn an errprof object returned from \code{\link{impute_errors}}
-#' @param plotType chr string indicating plot type, accepted values are \code{"boxplot"} or \code{"bar"}
+#' @param plotType chr string indicating plot type, accepted values are \code{"boxplot"}, \code{"bar"}, or \code{"line"}
 #' @param \dots arguments passed to or from other methods
 #'
-#' @return A ggplot object that can be further modified.  The entire range of errors are shown if \code{plotType = "boxplot"}, otherwise the averages are shown if \code{plotType = "bar"}.
+#' @return A ggplot object that can be further modified.  The entire range of errors are shown if \code{plotType = "boxplot"}, otherwise the averages are shown if \code{plotType = "bar"} or \code{"line"}.
 #'
 #' @importFrom  reshape2 melt
 #' @import ggplot2
@@ -15,6 +15,7 @@
 #' aa <- impute_errors()
 #' plot_errors(aa)
 #' plot_errors(aa, plotType = 'bar')
+#' plot_errors(aa, plotType = 'line')
 plot_errors <- function(dataIn, ...) UseMethod('plot_errors')
 
 #' @rdname plot_errors
@@ -24,9 +25,10 @@ plot_errors <- function(dataIn, ...) UseMethod('plot_errors')
 #' @method plot_errors errprof
 plot_errors.errprof <- function(dataIn, plotType = c('boxplot'), ...){
 
-  if(!plotType %in% c('boxplot', 'bar'))
-    stop('plotType must be boxplot or bar')
+  if(!plotType %in% c('boxplot', 'bar', 'line'))
+    stop('plotType must be boxplot, bar, or line')
 
+  # boxplot
   if(plotType == 'boxplot'){
 
     toplo <- attr(dataIn, 'errall')
@@ -40,22 +42,39 @@ plot_errors.errprof <- function(dataIn, plotType = c('boxplot'), ...){
       geom_boxplot(aes(fill = Methods)) +
       theme_bw()
 
+    return(p)
+
   }
 
-  if(plotType == 'bar'){
+  # data for line or bar
+  toplo <- data.frame(dataIn[-1])
+  toplo <- melt(toplo, id.var = 'MissingPercent')
+  toplo$MissingPercent <- factor(toplo$MissingPercent)
+  names(toplo) <- c('Percent of missing values', 'Methods', 'Error value')
 
-    toplo <- data.frame(dataIn[-1])
-    toplo <- melt(toplo, id.var = 'MissingPercent')
-    toplo$Missing_Percent <- factor(toplo$MissingPercent)
-    names(toplo) <- c('Percent of missing values', 'Methods', 'Error value')
+  # barplot
+  if(plotType == 'bar'){
 
     p <- ggplot(toplo, aes(x = `Percent of missing values`, y = `Error value`)) +
       ggtitle(dataIn$Parameter) +
       geom_bar(aes(fill = Methods), stat = 'identity', position = 'dodge') +
       theme_bw()
 
+    return(p)
+
   }
 
-  return(p)
+  # line plot
+  if(plotType == 'line'){
+
+    p <- ggplot(toplo, aes(x = `Percent of missing values`, y = `Error value`, group = Methods)) +
+      ggtitle(dataIn$Parameter) +
+      geom_line() +
+      geom_point(aes(fill = Methods), shape = 21, size = 5) +
+      theme_bw()
+
+    return(p)
+
+  }
 
 }

--- a/R/sample_dat.R
+++ b/R/sample_dat.R
@@ -76,7 +76,9 @@ sample_dat <- function(datin, smps = 'mcar', repetition = 10, b = 50, blck = 50,
     # create samples for each repetition
     for(i in 1:repetition){
 
-      pool <- 1:length(datin)
+      # pool is the number of obs up to the max minus blck size
+      # ensures that those on the right do not overlap the end
+      pool <- 1:(length(datin) - blck + 1)
 
       # initial grab
       grbs <- sample(pool, blck_sd, replace = F) %>%

--- a/R/sample_dat.R
+++ b/R/sample_dat.R
@@ -124,7 +124,7 @@ sample_dat <- function(datin, smps = 'mcar', repetition = 10, b = 50, blck = 50,
   if(plot){
 
     miss <- is.na(out[[1]])
-    plot(1:length(datin), datin)
+    plot(1:length(datin), datin, xlab = '', ylab = 'Obs')
     points(which(miss), datin[miss], col = 'red')
 
 

--- a/man/plot_errors.Rd
+++ b/man/plot_errors.Rd
@@ -12,12 +12,12 @@ plot_errors(dataIn, ...)
 \arguments{
 \item{dataIn}{an errprof object returned from \code{\link{impute_errors}}}
 
-\item{plotType}{chr string indicating plot type, accepted values are \code{"boxplot"} or \code{"bar"}}
+\item{plotType}{chr string indicating plot type, accepted values are \code{"boxplot"}, \code{"bar"}, or \code{"line"}}
 
 \item{\dots}{arguments passed to or from other methods}
 }
 \value{
-A ggplot object that can be further modified.  The entire range of errors are shown if \code{plotType = "boxplot"}, otherwise the averages are shown if \code{plotType = "bar"}.
+A ggplot object that can be further modified.  The entire range of errors are shown if \code{plotType = "boxplot"}, otherwise the averages are shown if \code{plotType = "bar"} or \code{"line"}.
 }
 \description{
 Function to plot the Error Comparison
@@ -26,5 +26,6 @@ Function to plot the Error Comparison
 aa <- impute_errors()
 plot_errors(aa)
 plot_errors(aa, plotType = 'bar')
+plot_errors(aa, plotType = 'line')
 }
 


### PR DESCRIPTION
`plot_errors()` can show lines, in addition to boxplot and bar.

``` r
aa <- impute_errors()
plot_errors(aa, plotType = 'line')
```

![rplot](https://cloud.githubusercontent.com/assets/3086881/19314319/55348672-905f-11e6-9582-e722625a748a.png)
